### PR TITLE
Update requirements.txt

### DIFF
--- a/train_v1.1b/requirements.txt
+++ b/train_v1.1b/requirements.txt
@@ -15,3 +15,4 @@ transformers==4.30.2
 typed-argument-parser<1.8
 wandb
 urllib3<2
+pytest


### PR DESCRIPTION

```
  File "run_clm.py", line 51, in <module>
    from transformers.testing_utils import CaptureLogger
  File "/home/work/lifefeel/KoAlpaca/venv/lib/python3.8/site-packages/transformers/testing_utils.py", line 39, in <module>
    from _pytest.doctest import (
ModuleNotFoundError: No module named '_pytest'
```
`train_v1.1b/run_clm.py` 실행 시 위와 같이 transformers에서 pytest를 사용하는 부분이 있는데 requirements.txt 설치만으로는 같이 설치가 되지 않았습니다.

pytest도 설치되도록 라인을 추가하였습니다.