### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy
 rouge_score
 fire
 openai
-transformers>=4.26.1
+transformers>=4.26.1,<=4.29.2
 torch
 sentencepiece
 tokenizers==0.12.1


### PR DESCRIPTION
Tensor Parallel code 학습시 transformers 4.30 버전 이상의 Trainer에서 에러 발생 
`Model parameters were moved to incorrect devices, did call on model.cuda() or model.to(device)? If so, please avoid doing that `